### PR TITLE
Fix mobile chat header sticking on load

### DIFF
--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -434,7 +434,7 @@ const ChatPage: React.FC = () => {
           searchHook.isSearchMode ? 'lg:w-1/2' : 'w-full'
         }`}>
           {/* Chat Header - Fixed at top */}
-          <div className="px-4 sm:px-6 py-3 border-b border-gray-200 dark:border-gray-700 bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm z-10 sticky top-0">
+          <div className="flex-shrink-0 px-4 sm:px-6 py-3 border-b border-gray-200 dark:border-gray-700 bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm z-10">
             <div className="flex items-center justify-between">
               <div className="flex items-center min-w-0 flex-1">
                 <button
@@ -521,11 +521,9 @@ const ChatPage: React.FC = () => {
           </div>
 
           {/* Messages - Scrollable Area */}
-          <div className="flex-1 overflow-y-auto -mt-16 pt-16 pb-4 px-4 sm:px-6" style={{
+          <div className="flex-1 overflow-y-auto px-4 sm:px-6 py-4" style={{
             WebkitOverflowScrolling: 'touch',
-            scrollBehavior: 'smooth',
-            scrollPaddingTop: '4rem',
-            scrollPaddingBottom: '4rem'
+            scrollBehavior: 'smooth'
           }}>
             <MessageList 
               messages={conversationMessages} 
@@ -535,7 +533,7 @@ const ChatPage: React.FC = () => {
           </div>
 
           {/* Message Input - Fixed at Bottom */}
-          <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm sticky bottom-0 z-10">
+          <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm">
             <MessageInput 
               key={chatState.selectedConversation} 
               onSendMessage={handleSendMessage} 


### PR DESCRIPTION
# Pull Request

## Description
This PR addresses an issue where the chat header on mobile devices was not fixed at the top from the initial load, only becoming sticky after the user scrolled. The mobile layout has been refactored to ensure the header and footer are always fixed, with the message area being the sole scrollable component.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement (Improved mobile UX)
- [x] Code refactoring

## Testing
- [x] Backend builds successfully
- [x] Frontend builds successfully
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [x] Manual testing completed (Verified mobile layout behavior)

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation made
- [x] No new warnings introduced
- [ ] Database migrations (if any) are backward compatible

## Screenshots (if applicable)
N/A

## Additional Notes
The previous layout used `sticky` positioning with conflicting negative margins and padding, leading to the header not being consistently fixed. This PR simplifies the layout using `flex-shrink-0` for the header and footer, and `flex-1 overflow-y-auto` for the message list, ensuring a robust fixed header/footer experience on mobile. A detailed summary of the changes and the new layout structure can be found in the conversation history.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b6887da-a15a-4e24-93de-9c5a47e39bf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b6887da-a15a-4e24-93de-9c5a47e39bf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>